### PR TITLE
Adding V-Z2P scaling to industrial-node-6/script.js

### DIFF
--- a/groups/treon/industrial-node-6/payloads/validScalarPayloadSingleAxis.json
+++ b/groups/treon/industrial-node-6/payloads/validScalarPayloadSingleAxis.json
@@ -1,19 +1,13 @@
 {
     "Vibration": {
-        "A-P2P": {
-            "Z": 329
+        "RMS": {
+            "Z": 93
         },
-        "Kurtosis": {
-            "Z": 294
+        "Z2P": {
+            "Z": 266
         },
-        "A-Z2P": {
-            "Z": 176
-        },
-        "A-RMS": {
-            "Z": 39
-        },
-        "Crest": {
-            "Z": 446
+        "P2P": {
+            "Z": 532
         },
         "UsedRange": {
             "Z": 10
@@ -21,11 +15,11 @@
     },
     "SourceAddress": "12991911",
     "SensorNodeId": "72a83dc6",
-    "Timestamp": 1724229573,
+    "Timestamp": 1724229567,
     "GatewayId": "728350bc",
     "MeasDetails": {
         "Id": 45633,
-        "CalcId": 3
+        "CalcId": 1
     },
     "Type": "scalar"
 }

--- a/groups/treon/industrial-node-6/payloads/validScalarPayloadSingleAxis.json
+++ b/groups/treon/industrial-node-6/payloads/validScalarPayloadSingleAxis.json
@@ -1,0 +1,31 @@
+{
+    "Vibration": {
+        "A-P2P": {
+            "Z": 329
+        },
+        "Kurtosis": {
+            "Z": 294
+        },
+        "A-Z2P": {
+            "Z": 176
+        },
+        "A-RMS": {
+            "Z": 39
+        },
+        "Crest": {
+            "Z": 446
+        },
+        "UsedRange": {
+            "Z": 10
+        }
+    },
+    "SourceAddress": "12991911",
+    "SensorNodeId": "72a83dc6",
+    "Timestamp": 1724229573,
+    "GatewayId": "728350bc",
+    "MeasDetails": {
+        "Id": 45633,
+        "CalcId": 3
+    },
+    "Type": "scalar"
+}

--- a/groups/treon/industrial-node-6/script.js
+++ b/groups/treon/industrial-node-6/script.js
@@ -110,6 +110,7 @@ function parseScalarPayload(payload, context, subjectExternalId, timestamp) {
             "A-P2P": defaultScalar,
             "V-RMS": defaultScalar,
             "A-RMS": defaultScalar,
+            "V-Z2P": defaultScalar,
             "A-Z2P": defaultScalar,
             Kurtosis: defaultScalar,
             Crest: defaultScalar,

--- a/groups/treon/industrial-node-6/tests.yml
+++ b/groups/treon/industrial-node-6/tests.yml
@@ -59,6 +59,9 @@ valid-single-axis-scalar-payload:
         - ingestionId: 72a83dc6$V-P2P-Z
           value: 5.32
           date: 2024-08-21T08:39:27.000+00:00
+        - ingestionId: 72a83dc6$UsedRange-Z
+          value: 10
+          date: 2024-08-21T08:39:27.000Z
 
 valid-burst-payload:
     description: scalar payload

--- a/groups/treon/industrial-node-6/tests.yml
+++ b/groups/treon/industrial-node-6/tests.yml
@@ -33,13 +33,13 @@ default:
           value: 401.3
           date: 2021-09-07T10:36:07.000+00:00
         - ingestionId: f07970e4$V-Z2P-X
-          value: 9346
+          value: 93.46
           date: 2021-09-07T10:36:07.000+00:00
         - ingestionId: f07970e4$V-Z2P-Y
-          value: 6096
+          value: 60.96
           date: 2021-09-07T10:36:07.000+00:00
         - ingestionId: f07970e4$V-Z2P-Z
-          value: 25764
+          value: 257.64
           date: 2021-09-07T10:36:07.000+00:00
 
 valid-empty-scalar-payload:
@@ -52,13 +52,13 @@ valid-single-axis-scalar-payload:
     expectedMeasurements:
         - ingestionId: 72a83dc6$V-RMS-Z
           value: 0.93
-          date: 2024-08-21T10:39:27.000+00:00
+          date: 2024-08-21T08:39:27.000+00:00
         - ingestionId: 72a83dc6$V-Z2P-Z
           value: 2.66
-          date: 2024-08-21T10:39:27.000+00:00
+          date: 2024-08-21T08:39:27.000+00:00
         - ingestionId: 72a83dc6$V-P2P-Z
           value: 5.32
-          date: 2024-08-21T10:39:27.000+00:00
+          date: 2024-08-21T08:39:27.000+00:00
 
 valid-burst-payload:
     description: scalar payload
@@ -95,13 +95,13 @@ valid-burst-payload:
           value: 401.3
           date: 2021-09-07T10:36:07.000+00:00
         - ingestionId: f07970e4$V-Z2P-X
-          value: 9346.0
+          value: 93.46
           date: 2021-09-07T10:36:07.000+00:00
         - ingestionId: f07970e4$V-Z2P-Y
-          value: 6096.0
+          value: 60.96
           date: 2021-09-07T10:36:07.000+00:00
         - ingestionId: f07970e4$V-Z2P-Z
-          value: 25764.0
+          value: 257.64
           date: 2021-09-07T10:36:07.000+00:00
 
 valid-scalar-fft:

--- a/groups/treon/industrial-node-6/tests.yml
+++ b/groups/treon/industrial-node-6/tests.yml
@@ -46,6 +46,20 @@ valid-empty-scalar-payload:
     description: empty payload
     payload: ./payloads/validEmptyScalarPayload.json
 
+valid-single-axis-scalar-payload:
+    description: single-axis scalar payload
+    payload: ./payloads/validScalarPayloadSingleAxis.json
+    expectedMeasurements:
+        - ingestionId: 72a83dc6$V-RMS-Z
+          value: 0.93
+          date: 2024-08-21T10:39:27.000+00:00
+        - ingestionId: 72a83dc6$V-Z2P-Z
+          value: 2.66
+          date: 2024-08-21T10:39:27.000+00:00
+        - ingestionId: 72a83dc6$V-P2P-Z
+          value: 5.32
+          date: 2024-08-21T10:39:27.000+00:00
+
 valid-burst-payload:
     description: scalar payload
     payload: ./payloads/validScalarPayload.json


### PR DESCRIPTION
V-Z2P was not defined in const scaledValues, therefore it was not divided by 100 in the final payload. This PR adds V-Z2P to the cost scaledValues so the corresponding data is scaled properly.